### PR TITLE
Login/signup error validation

### DIFF
--- a/iOS/dough-bros-ios/View/Welcome/SignUpViewController.swift
+++ b/iOS/dough-bros-ios/View/Welcome/SignUpViewController.swift
@@ -56,7 +56,10 @@ class SignUpViewController: UIViewController, LoginButtonDelegate {
         firstNameInput.addTarget(self, action: #selector(textFieldsNotEmpty), for: .editingChanged)
         lastNameInput.addTarget(self, action: #selector(textFieldsNotEmpty), for: .editingChanged)
         emailInput.addTarget(self, action: #selector(textFieldsNotEmpty), for: .editingChanged)
+        emailInput.addTarget(self, action: #selector(emailInputDidChange(_:)), for: .editingChanged)
         passwordInput.addTarget(self, action: #selector(textFieldsNotEmpty), for: .editingChanged)
+        passwordInput.addTarget(self, action: #selector(passwordInputDidChange(_:)), for: .editingChanged)
+
     }
     
     @objc func textFieldsNotEmpty(sender: UITextField) {
@@ -64,11 +67,54 @@ class SignUpViewController: UIViewController, LoginButtonDelegate {
            let lastName = lastNameInput.text, !lastName.isEmpty,
            let email = emailInput.text, !email.isEmpty,
            let password = passwordInput.text, !password.isEmpty {
-            signupView.signUpButton.backgroundColor = UIColor(hex: 0xF8A096)
-            signupView.signUpButton.isEnabled = true
+            let validPassword = NSPredicate(format: "SELF MATCHES %@ ", "^(?=.*[a-z])(?=.*[$@$#!%*?&]).{8,}$")
+            if (validPassword.evaluate(with: password)) {
+                signupView.signUpButton.backgroundColor = UIColor(hex: 0xF8A096)
+                signupView.signUpButton.isEnabled = true
+            }
         } else {
             signupView.signUpButton.backgroundColor = UIColor(hex: 0xD8D8D8)
             signupView.signUpButton.isEnabled = false
+        }
+    }
+    
+    func isValidEmailAddress(emailAddressString: String) -> Bool {
+       
+       var returnValue = true
+       let emailRegEx = "[A-Z0-9a-z.-_]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,3}"
+       
+       do {
+           let regex = try NSRegularExpression(pattern: emailRegEx)
+           let nsString = emailAddressString as NSString
+           let results = regex.matches(in: emailAddressString, range: NSRange(location: 0, length: nsString.length))
+           
+           if results.count == 0
+           {
+               returnValue = false
+           }
+           
+       } catch let error as NSError {
+           print("invalid regex: \(error.localizedDescription)")
+           returnValue = false
+       }
+       
+       return  returnValue
+    }
+    
+    @objc func emailInputDidChange(_ textField: DBTextField) {
+        if (!isValidEmailAddress(emailAddressString: textField.text!)) {
+            textField.styleBottomBorder(color: .red)
+        } else {
+            textField.styleBottomBorder(color: .black)
+        }
+    }
+    
+    @objc func passwordInputDidChange(_ textField: DBTextField) {
+        let validPassword = NSPredicate(format: "SELF MATCHES %@ ", "^(?=.*[a-z])(?=.*[$@$#!%*?&]).{8,}$")
+        if (!validPassword.evaluate(with: textField.text)) {
+            textField.styleBottomBorder(color: .red)
+        } else {
+            textField.styleBottomBorder(color: .black)
         }
     }
     

--- a/iOS/dough-bros-ios/View/Welcome/WelcomeView.swift
+++ b/iOS/dough-bros-ios/View/Welcome/WelcomeView.swift
@@ -54,6 +54,17 @@ class WelcomeView: UIView, UITextFieldDelegate {
         return label
     }()
     
+    private(set) var errorLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .red
+        label.text = ""
+        label.font = UIFont.systemFont(ofSize: 16)
+        label.lineBreakMode = .byWordWrapping
+        label.numberOfLines = 0
+        return label
+    }()
+    
     private var loginStack: DBStackView = {
         let stack = DBStackView(axis: .vertical, alignment: .fill, spacing: 50)
         return stack
@@ -189,6 +200,13 @@ class WelcomeView: UIView, UITextFieldDelegate {
         NSLayoutConstraint.activate([
             signInLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
             signInLabel.centerYAnchor.constraint(equalTo: signInButton.centerYAnchor)
+        ])
+        
+        addSubview(errorLabel)
+        NSLayoutConstraint.activate([
+            errorLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 30),
+            errorLabel.bottomAnchor.constraint(equalTo: loginStack.topAnchor, constant: -30),
+            errorLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -30)
         ])
         
         addSubview(facebookLoginButton)

--- a/iOS/dough-bros-ios/View/Welcome/WelcomeViewController.swift
+++ b/iOS/dough-bros-ios/View/Welcome/WelcomeViewController.swift
@@ -74,8 +74,12 @@ class WelcomeViewController: UIViewController, LoginButtonDelegate {
         print(emailInput.text!, passwordInput.text!)
         Auth.auth().signIn(withEmail: emailInput.text!, password: passwordInput.text!) { [weak self] authResult, error in
           guard let strongSelf = self else { return }
-          print(authResult)
-            self!.welcomeView.UID.text = authResult?.user.uid
+            if let err = error {
+                print("error is \(err.localizedDescription)")
+                strongSelf.welcomeView.errorLabel.text = err.localizedDescription
+            }
+          print("authResult: \(authResult)")
+        strongSelf.welcomeView.UID.text = authResult?.user.uid
         }
     }
     


### PR DESCRIPTION
whoops I created this branch a while ago but forgot to make a PR 😅

- login returns corresponding firebase error on UI
- signup has email and password format validation (haven't implemented message on UI, not sure how design wants this to look! bring up at meeting) see attached picture
- where do you want the email/password format error message to be?

![Screen Shot 2021-01-31 at 6 12 23 PM](https://user-images.githubusercontent.com/3856856/106407092-60159b00-63f8-11eb-93fd-fd0f460d9e4f.png)

- was comparing WelcomeView (where users log in) and SignUpView (where users sign up) to LoginView (Harin's previous view) and I think? I implemented/split the API class calls between the two new views last term? 
- `getToken()` in SignUpViewController, `loginAction()` in WelcomeViewController? Not sure if it's correct/how to test so help on this would be appreciated :)

